### PR TITLE
switched token to header argument

### DIFF
--- a/bin/check-consul-failures.rb
+++ b/bin/check-consul-failures.rb
@@ -59,8 +59,16 @@ class ConsulStatus < Sensu::Plugin::Check::CLI
          boolean: true,
          default: false
 
+  option :token,
+         description: 'ACL token',
+         long: '--token ACL_TOKEN'
+
   def run
-    r = RestClient::Resource.new("#{config[:scheme]}://#{config[:server]}:#{config[:port]}/v1/agent/members", timeout: 5).get
+    r = RestClient::Resource.new(
+      "#{config[:scheme]}://#{config[:server]}:#{config[:port]}/v1/agent/members",
+      timeout: 5,
+      headers: { 'X-Consul-Token' => config[:token] }
+    ).get
     if r.code == 200
       failing_nodes = JSON.parse(r).find_all { |node| node['Status'] == 4 }
       if !failing_nodes.nil? && !failing_nodes.empty?

--- a/bin/check-consul-kv-ttl.rb
+++ b/bin/check-consul-kv-ttl.rb
@@ -95,17 +95,28 @@ class CheckConsulKvTTL < Sensu::Plugin::Check::CLI
          proc: proc { |a| a.to_i },
          default: 60
 
+  option :token,
+         description: 'ACL token',
+         long: '--token ACL_TOKEN'
+
   # Do work
   def run
     Diplomat.configure do |dip|
       dip.url = config[:consul]
+      dip.acl_token = config[:token]
     end
 
     begin
       # Retrieve the kv
       data = Diplomat::Kv.get(config[:kv])
-    rescue Faraday::ResourceNotFound
+    rescue Faraday::ResourceNotFound, Diplomat::KeyNotFound
       critical "Key/Value(#{config[:kv]}) pair does not exist in Consul."
+    rescue Diplomat::UnknownStatus => ex
+      if ex.message.include?(403)
+        critical %(ACL token is not authorized to access "#{config[:kv]}")
+      else
+        critical "Unhandled exception(#{e.class}) -- #{e.message}"
+      end
     rescue Exception => e # rubocop:disable Lint/RescueException
       critical "Unhandled exception(#{e.class}) -- #{e.message}"
     end

--- a/bin/check-consul-leader.rb
+++ b/bin/check-consul-leader.rb
@@ -104,7 +104,7 @@ class ConsulStatus < Sensu::Plugin::Check::CLI
     options = { timeout: config[:timeout],
                 verify_ssl: (OpenSSL::SSL::VERIFY_NONE if defined? config[:insecure]),
                 ssl_ca_file: (config[:capath] if defined? config[:capath]),
-                token: config[:token] }
+                headers: ({ 'X-Consul-Token' => config[:token] } if defined? config[:token]) }
     url = "#{config[:scheme]}://#{config[:server]}:#{config[:port]}/v1/status/leader"
 
     r = RestClient::Resource.new(url, options).get

--- a/bin/check-consul-leader.rb
+++ b/bin/check-consul-leader.rb
@@ -73,6 +73,10 @@ class ConsulStatus < Sensu::Plugin::Check::CLI
          long: '--timeout TIMEOUT_IN_SECONDS',
          default: 5
 
+  option :token,
+         description: 'ACL token',
+         long: '--token ACL_TOKEN'
+
   def valid_ip(ip)
     case ip.to_s
     when Resolv::IPv4::Regex
@@ -99,7 +103,8 @@ class ConsulStatus < Sensu::Plugin::Check::CLI
   def run
     options = { timeout: config[:timeout],
                 verify_ssl: (OpenSSL::SSL::VERIFY_NONE if defined? config[:insecure]),
-                ssl_ca_file: (config[:capath] if defined? config[:capath]) }
+                ssl_ca_file: (config[:capath] if defined? config[:capath]),
+                token: config[:token] }
     url = "#{config[:scheme]}://#{config[:server]}:#{config[:port]}/v1/status/leader"
 
     r = RestClient::Resource.new(url, options).get

--- a/bin/check-consul-maintenance.rb
+++ b/bin/check-consul-maintenance.rb
@@ -47,6 +47,10 @@ class MaintenanceStatus < Sensu::Plugin::Check::CLI
          long: '--node NODE',
          default: 'localhost'
 
+  option :token,
+         description: 'ACL token',
+         long: '--token ACL_TOKEN'
+
   # Get the maintenance data for the node from consul
   #
   def acquire_maintenance_data
@@ -69,6 +73,7 @@ class MaintenanceStatus < Sensu::Plugin::Check::CLI
   def run
     Diplomat.configure do |dc|
       dc.url = config[:consul]
+      dc.acl_token = config[:token]
     end
 
     data = acquire_maintenance_data

--- a/bin/check-consul-members.rb
+++ b/bin/check-consul-members.rb
@@ -94,11 +94,16 @@ class ConsulStatus < Sensu::Plugin::Check::CLI
          long: '--timeout TIMEOUT_IN_SECONDS',
          default: 5
 
+  option :token,
+         description: 'ACL token',
+         long: '--token ACL_TOKEN'
+
   def run
     url = "#{config[:scheme]}://#{config[:server]}:#{config[:port]}/v1/agent/members"
     options = { timeout: config[:timeout],
                 verify_ssl: (OpenSSL::SSL::VERIFY_NONE if defined? config[:insecure]),
-                ssl_ca_file: (config[:capath] if defined? config[:capath]) }
+                ssl_ca_file: (config[:capath] if defined? config[:capath]),
+                token: config[:token] }
 
     if config[:wan]
       url += '?wan=1'

--- a/bin/check-consul-members.rb
+++ b/bin/check-consul-members.rb
@@ -103,7 +103,7 @@ class ConsulStatus < Sensu::Plugin::Check::CLI
     options = { timeout: config[:timeout],
                 verify_ssl: (OpenSSL::SSL::VERIFY_NONE if defined? config[:insecure]),
                 ssl_ca_file: (config[:capath] if defined? config[:capath]),
-                token: config[:token] }
+                headers: ({ 'X-Consul-Token' => config[:token] } if defined? config[:token]) }
 
     if config[:wan]
       url += '?wan=1'

--- a/bin/check-consul-servers.rb
+++ b/bin/check-consul-servers.rb
@@ -88,11 +88,16 @@ class ConsulStatus < Sensu::Plugin::Check::CLI
          proc: proc(&:to_i),
          default: 5
 
+  option :token,
+         description: 'ACL token',
+         long: '--token ACL_TOKEN'
+
   def run
     url = "#{config[:scheme]}://#{config[:server]}:#{config[:port]}/v1/status/peers"
     options = { timeout: config[:timeout],
                 verify_ssl: (OpenSSL::SSL::VERIFY_NONE if defined? config[:insecure]),
-                ssl_ca_file: (config[:capath] if defined? config[:capath]) }
+                ssl_ca_file: (config[:capath] if defined? config[:capath]),
+                token: config[:token] }
 
     json = RestClient::Resource.new(url, options).get
     peers = JSON.parse(json).length.to_i

--- a/bin/check-consul-servers.rb
+++ b/bin/check-consul-servers.rb
@@ -97,7 +97,7 @@ class ConsulStatus < Sensu::Plugin::Check::CLI
     options = { timeout: config[:timeout],
                 verify_ssl: (OpenSSL::SSL::VERIFY_NONE if defined? config[:insecure]),
                 ssl_ca_file: (config[:capath] if defined? config[:capath]),
-                token: config[:token] }
+                headers: ({ 'X-Consul-Token' => config[:token] } if defined? config[:token]) }
 
     json = RestClient::Resource.new(url, options).get
     peers = JSON.parse(json).length.to_i

--- a/bin/check-consul-service-health.rb
+++ b/bin/check-consul-service-health.rb
@@ -70,6 +70,10 @@ class CheckConsulServiceHealth < Sensu::Plugin::Check::CLI
          short: '-f',
          long: '--fail-if-not-found'
 
+  option :token,
+         description: 'ACL token',
+         long: '--token ACL_TOKEN'
+
   # Get the service checks for the given service
   def acquire_service_data
     if config[:tags] && config[:service]
@@ -109,6 +113,7 @@ class CheckConsulServiceHealth < Sensu::Plugin::Check::CLI
 
     Diplomat.configure do |dc|
       dc.url = config[:consul]
+      dc.acl_token = config[:token]
     end
 
     found      = false

--- a/lib/sensu-plugins-consul/check/base.rb
+++ b/lib/sensu-plugins-consul/check/base.rb
@@ -82,7 +82,7 @@ module SensuPluginsConsul
 
       option :token,
              description: 'ACL token',
-             long: '--token ACL_TOKEN',
+             long: '--token ACL_TOKEN'
 
       #
       # Fetch and return the parsed JSON data from a specified Consul API endpoint.
@@ -93,8 +93,7 @@ module SensuPluginsConsul
         options = { timeout: config[:timeout],
                     verify_ssl: !config[:insecure],
                     ssl_ca_file: config[:capath],
-                    headers: { 'X-Consul-Token' => config[:token] }
-                  }
+                    headers: { 'X-Consul-Token' => config[:token] } }
 
         JSON.parse(RestClient::Resource.new(url, options).get)
       rescue Errno::ECONNREFUSED

--- a/test/lib/sensu-plugins-consul/check/base_spec.rb
+++ b/test/lib/sensu-plugins-consul/check/base_spec.rb
@@ -38,7 +38,8 @@ describe SensuPluginsConsul::Check::Base do
           .with('http://127.0.0.1:8500/v1/things',
                 timeout: 5,
                 verify_ssl: true,
-                ssl_ca_file: nil)
+                ssl_ca_file: nil,
+                headers: { 'X-Consul-Token' => nil })
           .and_return(double(get: '{"some":"json"}'))
       end
 
@@ -56,8 +57,7 @@ describe SensuPluginsConsul::Check::Base do
                 timeout: 5,
                 verify_ssl: false,
                 ssl_ca_file: '/etc/ca',
-                headers: { 'X-Consul-Token' => 'foo' }
-               )
+                headers: { 'X-Consul-Token' => nil })
           .and_return(double(get: '{"some":"json"}'))
       end
 


### PR DESCRIPTION
When testing it on my dev Consul cluster, supplying the token would not work until I changed it into a `headers: 'X-Consul-Token: ` argument as shown in the Consul API documentation 
